### PR TITLE
国際化関連コードの整理

### DIFF
--- a/classes/class-main.php
+++ b/classes/class-main.php
@@ -17,7 +17,6 @@ class Main {
 	public $service = array();
 
 	public function __construct() {
-		add_action( 'plugins_loaded', array( $this, 'load_textdomain' ) );
 		$this->option = get_option( WPAP_ID, array() );
 		$this->cache  = new Cache();
 
@@ -79,10 +78,6 @@ class Main {
 				'render_callback' => array($this, 'gutenberg_callback'),
 			));
 		}
-	}
-
-	public function load_textdomain() {
-		load_plugin_textdomain( 'wp-associate-post-r2' );
 	}
 
 	public function init() {
@@ -154,29 +149,18 @@ class Main {
 	public function admin_enqueue( $hook ) {
 		if ( 'settings_page_' . WPAP_ID === $hook ) {
 			wp_enqueue_style( 'wpap-admin-option', WPAP_PLUGIN_URL . 'css/admin-option.css', array(), WPAP_VERSION );
-			wp_enqueue_script( 'wpap-admin-option', WPAP_PLUGIN_URL . 'js/admin-option.js', array( 'jquery' ), WPAP_VERSION, true );
+			wp_enqueue_script( 'wpap-admin-option', WPAP_PLUGIN_URL . 'js/admin-option.js', array( 'wp-i18n', 'jquery' ), WPAP_VERSION, true );
 			wp_localize_script( 'wpap-admin-option', 'wpapOption', array(
 				'ajaxURL'       => admin_url( 'admin-ajax.php' ),
 				'nonce'         => wp_create_nonce( 'wpap_cache_clear' ),
 				'loadingImgURL' => WPAP_PLUGIN_URL . 'images/loading_mini.gif',
-				'i18n'          => array(
-					'clearingCache'         => __( 'Clearing the cache... Please wait a moment.', 'wp-associate-post-r2' ),
-					'communicationError'    => __( 'A communication error occurred. Please try again in a moment.', 'wp-associate-post-r2' ),
-					'importFileNotSelected' => __( 'File not selected.', 'wp-associate-post-r2' ),
-					'importConfirm'         => __( 'The setting will be overridden. If you select the wrong file, the setting may be corrupt or disappear, so please verify you have selected the correct file. Are you sure you want to import?', 'wp-associate-post-r2' ),
-				),
 			) );
 		} elseif ( 'media-upload-popup' === $hook && isset( $_GET['tab'] ) && preg_match( '/^(' . WPAP_ID_ABBR . '_)/', $_GET['tab'] ) ) {
 			wp_enqueue_style( 'font-awesome', 'https://maxcdn.bootstrapcdn.com/font-awesome/4.6.1/css/font-awesome.min.css', array(), null );
 			wp_enqueue_style( 'wpap-admin-search', WPAP_PLUGIN_URL . 'css/admin-search.css', array( 'font-awesome' ), WPAP_VERSION );
 			wp_enqueue_script( 'jquery-pjax', WPAP_PLUGIN_URL . 'js/jquery.pjax.min.js', array( 'jquery' ), null, true );
-			wp_enqueue_script( 'wpap-admin-search', WPAP_PLUGIN_URL . 'js/admin-search.js', array( 'jquery', 'jquery-pjax' ), WPAP_VERSION, true );
-			wp_localize_script( 'wpap-admin-search', 'wpapSearch', array(
-				'isGutenberg' => $this->is_gutenberg_active(),
-				'i18n' => array(
-					'balloonRakutenAndYahooLinks' => __( 'In order to improve operating speed, Rakuten and Yahoo links can not be clicked from the preview screen.', 'wp-associate-post-r2' ),
-					),
-				) );
+			wp_enqueue_script( 'wpap-admin-search', WPAP_PLUGIN_URL . 'js/admin-search.js', array( 'wp-i18n', 'jquery', 'jquery-pjax' ), WPAP_VERSION, true );
+			wp_localize_script( 'wpap-admin-search', 'wpapSearch', array( 'isGutenberg' => $this->is_gutenberg_active() ) );
 			$this->enqueue();
 		} elseif ( in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {
 			wp_enqueue_style( 'wpap-admin-post', WPAP_PLUGIN_URL . 'css/admin-post.css', array(), WPAP_VERSION );

--- a/js/admin-option.js
+++ b/js/admin-option.js
@@ -2,11 +2,16 @@
 (function( $, wpapOption ) {
 
 	$( document ).ready(function() {
+		var __ = wp.i18n.__;
 
 		$( '#cache_clear' ).click(function() {
 			var $this = $( this );
-			$this.before( '<div class="notice notice-warning inline" id="wpap-cache-clear-loading"><p><img src="' +
-				wpapOption.loadingImgURL + '"> ' + wpapOption.i18n.clearingCache + '</p></div>' );
+			$this.before(
+				'<div class="notice notice-warning inline" id="wpap-cache-clear-loading"><p>' +
+				'<img src="' + wpapOption.loadingImgURL + '"> ' +
+				__( 'Clearing the cache... Please wait a moment.', 'wp-associate-post-r2' ) +
+				'</p></div>'
+			);
 			$this.prop( 'disabled', true );
 			$.ajax({
 				type: 'POST',
@@ -25,7 +30,11 @@
 					$this.prop( 'disabled', false );
 				}
 			}).fail(function() {
-				$this.before( '<div class="notice notice-error inline"><p>' + wpapOption.i18n.communicationError + '</p></div>' );
+				$this.before(
+					'<div class="notice notice-error inline"><p>' +
+					__( 'A communication error occurred. Please try again in a moment.', 'wp-associate-post-r2' ) +
+					'</p></div>'
+				);
 				$this.prop( 'disabled', false );
 			}).always(function() {
 				$( '#wpap-cache-clear-loading' ).remove();
@@ -35,10 +44,15 @@
 		$( '#import_form' ).submit(function() {
 			var file = $( 'input[name=option_import_file]' )[0].files[0];
 			if ( ! file ) {
-				window.alert( wpapOption.i18n.importFileNotSelected );
+				window.alert( __( 'File not selected.', 'wp-associate-post-r2' ) );
 				return false;
 			}
-			return window.confirm( wpapOption.i18n.importConfirm );
+			return window.confirm(
+				__(
+					'The setting will be overridden. If you select the wrong file, the setting may be corrupt or disappear, so please verify you have selected the correct file. Are you sure you want to import?',
+					'wp-associate-post-r2'
+				),
+			);
 		});
 
 	});

--- a/js/admin-search.js
+++ b/js/admin-search.js
@@ -190,8 +190,11 @@
 		});
 
 		$( document ).on( 'mouseenter', '.wpap-link-rakuten, .wpap-link-yahoo', function() {
-			$( this ).closest( '.display-preview' )
-				.append( '<div class="wpap-balloon"><p>' + wpapSearch.i18n.balloonRakutenAndYahooLinks + '</p></div>' );
+			var label = parent.wp.i18n.__(
+				'In order to improve operating speed, Rakuten and Yahoo links can not be clicked from the preview screen.',
+				'wp-associate-post-r2'
+			);
+			$( this ).closest( '.display-preview' ).append( '<div class="wpap-balloon"><p>' + label + '</p></div>' );
 		}).on( 'mouseleave', '.wpap-link-rakuten, .wpap-link-yahoo', function() {
 			$( this ).closest( '.display-preview' ).find( '.wpap-balloon' )
 				.fadeOut()

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WP Associate Post R2 ===
 Contributors: delightstar, satonyan, cibea
 Tags: affiliate, amazon, rakuten, yahoo, media, post, links
-Requires at least: 4.5
+Requires at least: 4.6
 Tested up to: 5.3
 Requires PHP: 5.6
 Stable tag: 4.2

--- a/wp-associate-post-r2.php
+++ b/wp-associate-post-r2.php
@@ -8,7 +8,6 @@ Version:     4.2
 Author:      Delight Star Inc.
 Author URI:  https://delight-star.co.jp/
 License:     GPLv2
-Text Domain: wp-associate-post-r2
 */
 
 namespace WP_Associate_Post_R2;


### PR DESCRIPTION
国際化関連コードの整理する。

- 翻訳文字列を `wp_localize_script` 関数でJSへ渡していたが、JS内で直接i18n関数を呼び出すように調整
- load_plugin_textdomain関数呼び出しを削除
- プラグインヘッダのText Domainを削除
- WP4.6以上動作に変更