### PR TITLE
PHP/WPエラー対応、一部翻訳されていない部分を調整

### DIFF
--- a/blocks/product/block.json
+++ b/blocks/product/block.json
@@ -33,5 +33,5 @@
     "alignWide": false
   },
   "textdomain": "wp-associate-post-r2",
-  "editorScript": "file:./index.js"
+  "editorScript": "file:index.js"
 }

--- a/blocks/product/src/block.json
+++ b/blocks/product/src/block.json
@@ -33,5 +33,5 @@
 		"alignWide": false
 	},
 	"textdomain": "wp-associate-post-r2",
-	"editorScript": "file:./index.js"
+	"editorScript": "file:index.js"
 }

--- a/classes/class-cache.php
+++ b/classes/class-cache.php
@@ -48,7 +48,7 @@ class Cache {
 
 	public function save( $key, $data, $life_time = '1 day' ) {
 		// 作成日時・有効期限を設定
-		$datetime         = new DateTime( null, new DateTimeZone( 'UTC' ) );
+		$datetime         = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		$created_datetime = $datetime->format( 'Y-m-d H:i:s' );
 		$expire_datetime  = $datetime->add( DateInterval::createFromDateString( $life_time ) )->format( 'Y-m-d H:i:s' );
 		$serialize_data   = json_encode( $data );
@@ -64,7 +64,7 @@ class Cache {
 	}
 
 	public function clean() {
-		$datetime     = new DateTime( null, new DateTimeZone( 'UTC' ) );
+		$datetime     = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
 		$now_datetime = $datetime->format( 'Y-m-d H:i:s' );
 		$sql          = $this->wpdb->prepare( "DELETE FROM $this->table WHERE expire_date_gmt < %s;", $now_datetime ); // WPCS: unprepared SQL OK
 		$this->wpdb->query( $sql ); // WPCS: unprepared SQL OK

--- a/classes/class-main.php
+++ b/classes/class-main.php
@@ -63,16 +63,16 @@ class Main {
 			add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 			add_action( 'admin_init', array( $this, 'admin_init' ) );
 		}
+	}
 
+	public function init() {
 		if ( function_exists( 'register_block_type' ) && ! is_null( $this->get_search_tab_id() ) ) {
 			register_block_type( WPAP_PLUGIN_PATH . '/blocks/product', array(
 				'render_callback' => array($this, 'gutenberg_callback'),
 			) );
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		}
-	}
 
-	public function init() {
 		$this->template = new Template();
 		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ) );
 		add_shortcode( WPAP_ID_ABBR, array( $this, 'shortcode' ) );

--- a/classes/class-main.php
+++ b/classes/class-main.php
@@ -70,6 +70,11 @@ class Main {
 			register_block_type( WPAP_PLUGIN_PATH . '/blocks/product', array(
 				'render_callback' => array($this, 'gutenberg_callback'),
 			) );
+			$block_script_handle = generate_block_asset_handle( 'wp-associate-post-r2/product', 'editorScript' );
+			wp_set_script_translations( $block_script_handle, 'wp-associate-post-r2' );
+			wp_localize_script( $block_script_handle, 'wpapBlockConfig', array(
+				'initTab' => $this->get_search_tab_id(),
+			) );
 			add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_block_editor_assets' ) );
 		}
 
@@ -162,11 +167,6 @@ class Main {
 	public function enqueue_block_editor_assets() {
 		add_thickbox();
 		$this->enqueue();
-		$block_script_handle = generate_block_asset_handle( 'wp-associate-post-r2/product', 'editorScript' );
-		wp_localize_script( $block_script_handle, 'wpapBlockConfig', array(
-				'initTab' => $this->get_search_tab_id(),
-		) );
-		wp_set_script_translations( $block_script_handle, 'wp-associate-post-r2' );
 	}
 
 	public function gutenberg_callback($attributes) {

--- a/classes/class-main.php
+++ b/classes/class-main.php
@@ -140,6 +140,7 @@ class Main {
 		if ( 'settings_page_' . WPAP_ID === $hook ) {
 			wp_enqueue_style( 'wpap-admin-option', WPAP_PLUGIN_URL . 'css/admin-option.css', array(), WPAP_VERSION );
 			wp_enqueue_script( 'wpap-admin-option', WPAP_PLUGIN_URL . 'js/admin-option.js', array( 'wp-i18n', 'jquery' ), WPAP_VERSION, true );
+			wp_set_script_translations( 'wpap-admin-option', 'wp-associate-post-r2' );
 			wp_localize_script( 'wpap-admin-option', 'wpapOption', array(
 				'ajaxURL'       => admin_url( 'admin-ajax.php' ),
 				'nonce'         => wp_create_nonce( 'wpap_cache_clear' ),
@@ -150,6 +151,7 @@ class Main {
 			wp_enqueue_style( 'wpap-admin-search', WPAP_PLUGIN_URL . 'css/admin-search.css', array( 'font-awesome' ), WPAP_VERSION );
 			wp_enqueue_script( 'jquery-pjax', WPAP_PLUGIN_URL . 'js/jquery.pjax.min.js', array( 'jquery' ), null, true );
 			wp_enqueue_script( 'wpap-admin-search', WPAP_PLUGIN_URL . 'js/admin-search.js', array( 'wp-i18n', 'jquery', 'jquery-pjax' ), WPAP_VERSION, true );
+			wp_set_script_translations( 'wpap-admin-search', 'wp-associate-post-r2' );
 			wp_localize_script( 'wpap-admin-search', 'wpapSearch', array( 'isGutenberg' => $this->is_gutenberg_active() ) );
 			$this->enqueue();
 		} elseif ( in_array( $hook, array( 'post.php', 'post-new.php' ), true ) ) {

--- a/js/admin-search.js
+++ b/js/admin-search.js
@@ -246,7 +246,7 @@
 				'mouseenter',
 				'.wpap-link-rakuten, .wpap-link-yahoo',
 				function () {
-					var label = parent.wp.i18n.__(
+					var label = wp.i18n.__(
 						'In order to improve operating speed, Rakuten and Yahoo links can not be clicked from the preview screen.',
 						'wp-associate-post-r2'
 					);


### PR DESCRIPTION
以下のPHP/WordPressエラーが発生している。

```
Notice: Function _load_textdomain_just_in_time was called incorrectly. Translation loading for the wp-associate-post-r2 domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the init action or later. Please see Debugging in WordPress for more information. (This message was added in version 6.7.0.)
Notice: Function wp_script_is was called incorrectly. Scripts and styles should not be registered or enqueued until the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks. This notice was triggered by the wp-associate-post-r2-product-editor-script handle. Please see Debugging in WordPress for more information. (This message was added in version 3.3.0.)
Notice: Function wp_register_script was called incorrectly. Scripts and styles should not be registered or enqueued until the wp_enqueue_scripts, admin_enqueue_scripts, or login_enqueue_scripts hooks. This notice was triggered by the wp-associate-post-r2-product-editor-script handle. Please see Debugging in WordPress for more information. (This message was added in version 3.3.0.)
```

```
Deprecated: DateTime::__construct(): Passing null to parameter #1 ($datetime) of type string is deprecated
```

また、一部翻訳されていない部分があるため、調整を行う。